### PR TITLE
Jokers of Neon: add capcitor urls to origins

### DIFF
--- a/configs/jokers-of-neon/config.json
+++ b/configs/jokers-of-neon/config.json
@@ -1,5 +1,5 @@
 {
-  "origin": "*.jokersofneon.com",
+  "origin": ["*.jokersofneon.com", "capacitor://localhost", "http://localhost"],
   "theme": {
     "colors": {
       "primary": "#A144B2"

--- a/configs/jokers-of-neon/config.json
+++ b/configs/jokers-of-neon/config.json
@@ -1,5 +1,5 @@
 {
-  "origin": ["*.jokersofneon.com", "capacitor://localhost", "http://localhost"],
+  "origin": ["*.jokersofneon.com", "capacitor://localhost", "localhost"],
   "theme": {
     "colors": {
       "primary": "#A144B2"


### PR DESCRIPTION
This intends to remove the red warning on the controller for capacitor native app environments