### PR TITLE
Pistols v1.2.2

### DIFF
--- a/configs/pistols/config.json
+++ b/configs/pistols/config.json
@@ -1,6 +1,8 @@
 {
   "origin": [
+    "pistols.gg",
     "*.pistols.gg",
+    "underware.gg",
     "*.underware.gg"
   ],
   "theme": {
@@ -172,6 +174,15 @@
               {
                 "entrypoint": "airdrop_ring",
                 "description": "Airdrop Signet Rings (admin)"
+              }
+            ]
+          },
+          "0x068a7a07e08fc3e723a878223d00f669106780d5ea6665eb15d893476d47bf3b": {
+            "description": "$FOOLS ERC20 contract (Players rewards)",
+            "methods": [
+              {
+                "entrypoint": "approve",
+                "description": "Approve use of FOOLS (in-game currency)"
               }
             ]
           },
@@ -470,6 +481,15 @@
               {
                 "entrypoint": "airdrop_ring",
                 "description": "Airdrop Signet Rings (admin)"
+              }
+            ]
+          },
+          "0x068a7a07e08fc3e723a878223d00f669106780d5ea6665eb15d893476d47bf3b": {
+            "description": "$FOOLS ERC20 contract (Players rewards)",
+            "methods": [
+              {
+                "entrypoint": "approve",
+                "description": "Approve use of FOOLS (in-game currency)"
               }
             ]
           },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds FOOLS ERC20 contract (approve) to SN_MAIN and SN_SEPOLIA policies and includes base domains in allowed origins.
> 
> - **Config (`configs/pistols/config.json`)**:
>   - **Origins**: Add `pistols.gg` and `underware.gg` to `origin` alongside existing wildcards.
>   - **Policies**:
>     - **SN_MAIN**: Add `$FOOLS` ERC20 contract `0x068a7a07e08fc3e723a878223d00f669106780d5ea6665eb15d893476d47bf3b` with `approve` method.
>     - **SN_SEPOLIA**: Add `$FOOLS` ERC20 contract `0x068a7a07e08fc3e723a878223d00f669106780d5ea6665eb15d893476d47bf3b` with `approve` method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ede6d47a35c94fd571c9263b26b4d330a1af99e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->