### PR TITLE
Update olas contracts

### DIFF
--- a/configs/olas/config.json
+++ b/configs/olas/config.json
@@ -8,7 +8,7 @@
         "SN_MAIN": {
             "policies": {
                 "contracts": {
-                    "0x079e8b3a275b1cbb392cfafc95ab4dc07e915ff7782fc34359fb463678ebcf94": {
+                    "0x0029f9d1603e4a91cc646473c40e103acf8d1bdb13f9461f10735616acb8617f": {
                         "name": "Olas Competitions Registry",
                         "description": "Allows users to interact with the Olas competitions registry contract.",
                         "methods": [
@@ -20,7 +20,7 @@
                             }
                         ]
                     },
-                    "0x032cf6562db58c2e8995d61d098bde2df73487327d68966d9f55f350be78032a": {
+                    "0x07337123974693342d97a1d27670796793cfec44b7953e9a35629efee4e35811": {
                         "name": "Olas Competition",
                         "description": "Allows users to interact with the Olas competition contract.",
                         "methods": [


### PR DESCRIPTION
updates olas mainnet contract addresses 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates two SN_MAIN contract addresses in `configs/olas/config.json` for the competitions registry and competition contracts.
> 
> - **Config** (`configs/olas/config.json`):
>   - **SN_MAIN → policies.contracts**:
>     - Update `Olas Competitions Registry` address to `0x0029f9d1603e4a91cc646473c40e103acf8d1bdb13f9461f10735616acb8617f`.
>     - Update `Olas Competition` address to `0x07337123974693342d97a1d27670796793cfec44b7953e9a35629efee4e35811`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46373ecfe503b07d7a9f4d1def067a015e4426e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->