### PR TITLE
feat: enforce approval limits for approve methods

### DIFF
--- a/scripts/validate-configs.ts
+++ b/scripts/validate-configs.ts
@@ -143,9 +143,10 @@ function checkApproveEntrypoints(
     for (const [contractAddress, contract] of Object.entries(
       chain.policies.contracts
     )) {
-      if (!contract.methods) continue;
+      const typedContract = contract as ConfigContract;
+      if (!typedContract.methods) continue;
 
-      for (const method of contract.methods) {
+      for (const method of typedContract.methods) {
         if (method.entrypoint === "approve") {
           approveOccurrence++;
           const searchString = `"approve"`;
@@ -155,12 +156,15 @@ function checkApproveEntrypoints(
             approveOccurrence
           );
 
-          errors.push({
-            file: configPath,
-            line,
-            message: `Usage of 'approve' entrypoint detected in chain ${chainId}, contract ${contractAddress}`,
-            type: "warning",
-          });
+          // Check if the method has an 'amount' field
+          if (!("amount" in method) || method.amount === undefined) {
+            errors.push({
+              file: configPath,
+              line,
+              message: `Approve entrypoint in chain ${chainId}, contract ${contractAddress} must have an 'amount' field specified`,
+              type: "error",
+            });
+          }
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export type ContractPolicies = Record<string, ContractPolicy>;
 export type ContractPolicy = {
   name?: string;
   description?: string;
-  methods: Method[];
+  methods: (Method | Approval)[];
 };
 
 export type PolicyPredicate = {
@@ -77,6 +77,15 @@ export type Method = {
    * @default true
    */
   isPaymastered?: boolean | PolicyPredicate;
+};
+
+export type Approval = Method & {
+  entrypoint: "approve";
+  /**
+   * Approval amount for methods that involve approvals (e.g., token approvals).
+   * Can be a numeric string to handle large numbers.
+   */
+  amount: string | number;
 };
 
 export type SignMessagePolicy = TypedDataPolicy & {


### PR DESCRIPTION
## Summary

This PR enforces that all approve methods in session policies must specify an approval limit amount.

## Changes

- **Type System**: Added `Approval` type that extends `Method` with a required `amount` field
- **Contract Policies**: Updated `ContractPolicy.methods` to accept `(Method | Approval)[]` union type
- **Validation**: Enhanced config validation to check that approve entrypoints have `amount` specified
- **Error Level**: Changed approve validation from warning to error to enforce the requirement

## Why

Approval methods need explicit limits to:
1. Improve security by preventing unlimited token approvals
2. Provide clarity on what amounts can be approved in a session
3. Ensure consistent policy definitions across all games

## Example

Before (invalid):
```json
{
  "entrypoint": "approve",
  "name": "Approve",
  "description": "Approve resource transfer"
}
```

After (valid):
```json
{
  "entrypoint": "approve",
  "name": "Approve", 
  "description": "Approve resource transfer",
  "amount": "1000000000000000000"
}
```

## Validation

The validation script now catches 17 configs with approve methods missing amount fields:
- dope-wars
- eternum
- jokers-of-neon (multiple chains)
- pistols (multiple chains)
- ponziland (5 contracts)
- zkube

These will need to be updated before the PR can merge.