### PR TITLE
gaffer: point SN_MAIN policies at hardened LeagueVault redeploy

### DIFF
--- a/configs/gaffer/config.json
+++ b/configs/gaffer/config.json
@@ -29,12 +29,12 @@
                 "name": "Approve league vault",
                 "description": "Authorises the Gaffer league vault to escrow your entry fee.",
                 "entrypoint": "approve",
-                "spender": "0x058be508d8a7f4522b223b78d3f1388e378faf22ede08427b64b8b8bd9db600c",
+                "spender": "0x3dcf0ebba29b6912c239ed02e7f7b3e0d3e5df82f53d54a5507dc24738ce419",
                 "amount": "0x5f5e100"
               }
             ]
           },
-          "0x058be508d8a7f4522b223b78d3f1388e378faf22ede08427b64b8b8bd9db600c": {
+          "0x3dcf0ebba29b6912c239ed02e7f7b3e0d3e5df82f53d54a5507dc24738ce419": {
             "name": "Gaffer League Vault",
             "description": "Smart escrow that holds every league's prize pool until settlement.",
             "methods": [


### PR DESCRIPTION
## Summary

Updates the `gaffer` preset's `SN_MAIN` block to point at a freshly deployed LeagueVault instance.

The previous mainnet vault (`0x058be508d8a7f4522b223b78d3f1388e378faf22ede08427b64b8b8bd9db600c`) was the pre-audit version. We found three fund-lock footguns in \`distribute()\` (empty winners array, zero-address winner, duplicate winner) plus a missing per-league pot solvency check. All four are now fixed and pinned by 35 passing snforge tests in our repo. We redeployed the hardened bytecode today and are retiring the old vault. No real funds ever flowed through the old one.

## New addresses

- **LeagueVault (SN_MAIN)**: \`0x3dcf0ebba29b6912c239ed02e7f7b3e0d3e5df82f53d54a5507dc24738ce419\`
- **Class hash**: \`0x5ebfc1ccae6cf91d546ab5f389fc2b43d31228494c3fdf45be383d3504de969\`

## Changes

Two places in \`configs/gaffer/config.json\`, both inside the \`SN_MAIN\` block:

1. USDC \`approve\` policy's \`spender\` field
2. The LeagueVault contract entry key

\`SN_SEPOLIA\` is untouched (testnet vault stays where it is, no money risk).

## Context

Hardening + test suite live at: github.com/itamardvir/fantasy-sports (commits \`98d6ace\`, \`3e9ed4b\`, \`30a37c4\`).

Coordinated with @tarrencev on Telegram. World Cup alpha launches in 4 weeks; would love to get this verified before then.