### PR TITLE
add Norwich Games Festival dungeon to death-mountain preset

### DIFF
--- a/configs/death-mountain/config.json
+++ b/configs/death-mountain/config.json
@@ -1,8 +1,5 @@
 {
-  "origin": [
-    "*.deathmountain.gg",
-    "deathmountain.gg"
-  ],
+  "origin": ["*.deathmountain.gg", "deathmountain.gg"],
   "chains": {
     "SN_MAIN": {
       "policies": {
@@ -141,6 +138,22 @@
                 "name": "Refresh Dungeon Stats",
                 "description": "Updates beast dungeon stats",
                 "entrypoint": "refresh_dungeon_stats"
+              }
+            ]
+          },
+          "0x04253e24220629b737512a24cb3172fc381db7be7a697d5af358ff21ef1172be": {
+            "name": "Norwich Games Festival Dungeon",
+            "description": "QR-claim dungeon for the Norwich Games Festival event. Scanning a leaflet QR mints free games; surviving to the level threshold mints a Black Shuck Beast collectible.",
+            "methods": [
+              {
+                "name": "Claim Game",
+                "description": "Redeem a scanned QR leaflet to mint free games",
+                "entrypoint": "claim_game"
+              },
+              {
+                "name": "Claim Reward",
+                "description": "Claim the Black Shuck Beast collectible after surviving to the dungeon's level threshold",
+                "entrypoint": "claim_reward"
               }
             ]
           }


### PR DESCRIPTION
## Summary

Adds policy entries for the Norwich Games Festival dungeon contract on mainnet (`0x04253e24220629b737512a24cb3172fc381db7be7a697d5af358ff21ef1172be`) so the Cartridge controller can pre-authorize the two entrypoints the festival flow signs:

- **`claim_game`** — bearer-credential claim called from the qr-drops claim webapp after a leaflet scan; mints free Denshokan game tokens.
- **`claim_reward`** — auto-claim fired by the death-mountain client once the player survives to the dungeon's level threshold; mints a Black Shuck Beast collectible NFT.

The preset is loaded by `claims.deathmountain.gg` (preset: `death-mountain`) so leaflet scanners see Death Mountain branding plus pre-approved policies for the festival.

## Test plan

- [ ] Festival flow: scan leaflet QR → controller prompts with Death Mountain branding and the two policies pre-approved
- [ ] `claim_game` executes without a per-call signature prompt
- [ ] `claim_reward` auto-fires from the death-mountain client at the threshold without an extra prompt