### PR TITLE
Add Olena V2 registry contract

### DIFF
--- a/configs/olena/config.json
+++ b/configs/olena/config.json
@@ -17,6 +17,12 @@
                                 "description": "A method to register a new world id verified user.",
                                 "entrypoint": "register_user",
                                 "is_paymastered": true
+                            },
+                            {
+                                "name": "Import Legacy Registration",
+                                "description": "A method to import an existing legacy registration.",
+                                "entrypoint": "import_legacy_registration",
+                                "is_paymastered": true
                             }
                         ]
                     },

--- a/configs/olena/config.json
+++ b/configs/olena/config.json
@@ -20,7 +20,7 @@
                             },
                             {
                                 "name": "Import Legacy Registration",
-                                "description": "A method to import an existing legacy registration.",
+                                "description": "A method to import an existing user registration from the legacy registry.",
                                 "entrypoint": "import_legacy_registration",
                                 "is_paymastered": true
                             }

--- a/configs/olena/config.json
+++ b/configs/olena/config.json
@@ -8,9 +8,9 @@
         "SN_MAIN": {
             "policies": {
                 "contracts": {
-                    "0x06ceedec593d93a175aeedf43b6f4035bb9f3ae9be03cc65d583ba4b7d42f3f2": {
-                        "name": "Olena Competitions Registry",
-                        "description": "Allows users to interact with the Olena competitions registry contract.",
+                    "0x041112ea865b703e0dae4eedb4850ef1553a70f9626fc2e27f30decfc263ac3f": {
+                        "name": "Olena Competitions Registry V2",
+                        "description": "Allows users to interact with the Olena competitions registry V2 contract.",
                         "methods": [
                             {
                                 "name": "Register User",


### PR DESCRIPTION
## Summary

Olena has a new V2 competitions registry deployment, but the preset was still granting registration policies against the previous registry contract address. Users relying on the preset would continue to request the relevant session policies for the legacy registry instead of the new V2 registry.

This PR replaces the Olena competitions registry entry with the V2 registry address and allows the V2 registration flows exposed by the deployed contract.

## Changes

- Updates the Olena competitions registry contract key to `0x041112ea865b703e0dae4eedb4850ef1553a70f9626fc2e27f30decfc263ac3f`.
- Renames the policy entry to `Olena Competitions Registry V2` and updates the description accordingly.
- Allows `register_user` for new V2 registrations.
- Allows `import_legacy_registration` for importing existing user registrations from the legacy registry.

## Verification

- Fast-forwarded the fork from upstream `cartridge-gg/presets:main` before branching.
- Verified the supplied Voyager URL path contains the same contract address: `0x041112ea865b703e0dae4eedb4850ef1553a70f9626fc2e27f30decfc263ac3f`.
- Verified the address is deployed on Starknet mainnet via RPC; `starknet_getClassHashAt` returned class hash `0x796d269ddf099ab4ade1a01dd100833d9bbf65d3f091e62819d11754a9e3426`.
- Fetched the class ABI and confirmed it is `IOlenaCompetitionRegistryV2` and exposes both `register_user` and `import_legacy_registration` as external entrypoints.
- Confirmed the incorrect `import_legacy_registry` entrypoint is not present in the ABI or config.
- Confirmed both Olena V2 registry methods are marked `is_paymastered: true`.
- Ran targeted config validation for `configs/olena/config.json` covering JSON parse, asset paths, origin format, policy nesting, required entrypoints, and paymaster flags.
- Ran `git diff --check`.

Note: the full `pnpm validate:configs` runner could not be executed in this local sandbox because Corepack/tsx attempted to create cache/IPC resources outside the allowed execution profile, so targeted checks were used for this JSON-only change.