### PR TITLE
Update Olena competition contract address

### DIFF
--- a/configs/olena/config.json
+++ b/configs/olena/config.json
@@ -26,7 +26,7 @@
                             }
                         ]
                     },
-                    "0x02cefa206485aa4c98b363fd7a2a86b276f7ae781903f86ea1f2db8b667911ad": {
+                    "0x06fe9a228fc5c355c2f0bfaa476fbc230322d4565110b7ba1ee67c311be4f349": {
                         "name": "Olena Competition",
                         "description": "Allows users to interact with the Olena competition contract.",
                         "methods": [


### PR DESCRIPTION
## Summary

Olena has a new competition contract deployment. The preset was still granting the competition session policies against the previous competition contract address, so users would continue to request `cast_vote` and `claim_market_refund` permissions for the old deployment.

This PR updates the Olena competition contract address while preserving the existing policy surface.

## Changes

- Replaces the Olena Competition contract key with `0x06fe9a228fc5c355c2f0bfaa476fbc230322d4565110b7ba1ee67c311be4f349`.
- Leaves the existing `cast_vote` and `claim_market_refund` methods unchanged.
- Keeps both competition methods marked `is_paymastered: true`.

## Verification

- Fast-forwarded the fork from upstream `cartridge-gg/presets:main` before branching.
- Verified the supplied Voyager URL path contains the same contract address: `0x06fe9a228fc5c355c2f0bfaa476fbc230322d4565110b7ba1ee67c311be4f349`.
- Verified the address is deployed on Starknet mainnet via RPC; `starknet_getClassHashAt` returned class hash `0x161bb4c6b70e3846c12ef865ac1919a224e66e5ee0fa43074abfe13748758e3`.
- Fetched the class ABI and confirmed it exposes `cast_vote` and `claim_market_refund` as external entrypoints.
- Ran targeted config validation for `configs/olena/config.json` covering JSON parse, assets, origin format, policy nesting, old-address removal, required competition entrypoints, and paymaster flags.
- Ran `git diff --check`.

Note: the full `pnpm validate:configs` runner was not used because this environment blocks the Corepack/tsx cache/IPC behavior seen in the previous Olena PR work, so targeted checks were used for this JSON-only address update.