### PR TITLE
feat: enable locationGate + ageGate for glitch-bomb

### DIFF
--- a/configs/glitch-bomb-mobile/config.json
+++ b/configs/glitch-bomb-mobile/config.json
@@ -1,5 +1,51 @@
 {
   "origin": "glitchbomb-ten.preview.cartridge.gg",
+  "locationGate": {
+    "allowed": [
+      "US-AL",
+      "US-AK",
+      "US-AZ",
+      "US-CA",
+      "US-CO",
+      "US-FL",
+      "US-GA",
+      "US-HI",
+      "US-ID",
+      "US-IL",
+      "US-IN",
+      "US-IA",
+      "US-KS",
+      "US-KY",
+      "US-ME",
+      "US-MD",
+      "US-MA",
+      "US-MN",
+      "US-MS",
+      "US-MO",
+      "US-NE",
+      "US-NH",
+      "US-NJ",
+      "US-NM",
+      "US-NY",
+      "US-NC",
+      "US-ND",
+      "US-OH",
+      "US-OK",
+      "US-OR",
+      "US-RI",
+      "US-SD",
+      "US-TN",
+      "US-UT",
+      "US-VT",
+      "US-WA",
+      "US-WV",
+      "US-WI",
+      "US-WY"
+    ]
+  },
+  "ageGate": {
+    "minimumAge": 18
+  },
   "apple-app-site-association": {
     "webcredentials": {
       "apps": [

--- a/configs/glitch-bomb/config.json
+++ b/configs/glitch-bomb/config.json
@@ -1,5 +1,51 @@
 {
   "origin": "glitchbomb-ten.preview.cartridge.gg",
+  "locationGate": {
+    "allowed": [
+      "US-AL",
+      "US-AK",
+      "US-AZ",
+      "US-CA",
+      "US-CO",
+      "US-FL",
+      "US-GA",
+      "US-HI",
+      "US-ID",
+      "US-IL",
+      "US-IN",
+      "US-IA",
+      "US-KS",
+      "US-KY",
+      "US-ME",
+      "US-MD",
+      "US-MA",
+      "US-MN",
+      "US-MS",
+      "US-MO",
+      "US-NE",
+      "US-NH",
+      "US-NJ",
+      "US-NM",
+      "US-NY",
+      "US-NC",
+      "US-ND",
+      "US-OH",
+      "US-OK",
+      "US-OR",
+      "US-RI",
+      "US-SD",
+      "US-TN",
+      "US-UT",
+      "US-VT",
+      "US-WA",
+      "US-WV",
+      "US-WI",
+      "US-WY"
+    ]
+  },
+  "ageGate": {
+    "minimumAge": 18
+  },
   "chains": {
     "SN_SEPOLIA": {
       "policies": {


### PR DESCRIPTION
## Summary
- Adds a `locationGate.allowed` list (39 US states) and `ageGate.minimumAge: 18` to both `configs/glitch-bomb/config.json` and `configs/glitch-bomb-mobile/config.json`, required for AppLovin real-money ad compliance.
- The allowlist uses only state-level codes (e.g. `US-CA`), never a bare `US` country code, so the controller's `evaluateLocationGate` fails closed for non-US IPs, US IPs with an unresolved/unknown region, and total IP-lookup failure (verified against `packages/keychain/src/utils/location-gate.ts` in cartridge-gg/controller).
- Covers **both** `glitch-bomb` and `glitch-bomb-mobile` presets identically.
- Schema and placement follow the existing `configs/nums/config.json` reference implementation (`LocationGateOptions` / `AgeGateOptions` in `src/index.ts`).

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run validate:configs` — glitch-bomb and glitch-bomb-mobile pass; the 3 pre-existing failures (dominion, eternum, metal-slug) are unrelated to this change.
- [x] Verified `allowed` array has exactly 39 unique entries in both files.

## Note
Pending owner review — **do not merge** without sign-off from the game/compliance owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)