### PR TITLE
Update death-mountain Game Treasury address and add claim_reward

### DIFF
--- a/configs/death-mountain/config.json
+++ b/configs/death-mountain/config.json
@@ -1,5 +1,5 @@
 {
-  "origin": ["*.deathmountain.gg", "deathmountain.gg", "connect.provable.games"],
+  "origin": ["*.deathmountain.gg", "deathmountain.gg", "connect.provable.games", "*.lootsurvivor.io", "lootsurvivor.io"],
   "chains": {
     "SN_MAIN": {
       "policies": {
@@ -146,7 +146,7 @@
               }
             ]
           },
-          "0x026663cefd82b58b0bdb56ff7d4b245a4b6b34c4761f5366ffb04fd58adc2fb9": {
+          "0x02a71609e235998a5ac140764e768a72a4e40d73e87a0d0858ba561bf875ee87": {
             "name": "Game Treasury",
             "description": "Verified-human free game distribution — claim a sponsored game",
             "methods": [
@@ -154,6 +154,11 @@
                 "name": "Claim Game",
                 "description": "Claim your free verified game",
                 "entrypoint": "claim_game"
+              },
+              {
+                "name": "Claim Reward",
+                "description": "Claim your reward",
+                "entrypoint": "claim_reward"
               }
             ]
           },


### PR DESCRIPTION
## Summary

Updates the **death-mountain** preset:

- **Game Treasury address** → `0x02a71609e235998a5ac140764e768a72a4e40d73e87a0d0858ba561bf875ee87`
- Authorizes the `claim_reward` entrypoint in addition to the existing `claim_game`, so users can claim rewards through the controller without an extra approval prompt.
- Adds `lootsurvivor.io` and `*.lootsurvivor.io` to the `origin` array.

## Changes

`origin`:
```json
["*.deathmountain.gg", "deathmountain.gg", "connect.provable.games", "*.lootsurvivor.io", "lootsurvivor.io"]
```

Game Treasury policy:
```json
"0x02a71609e235998a5ac140764e768a72a4e40d73e87a0d0858ba561bf875ee87": {
  "name": "Game Treasury",
  "description": "Verified-human free game distribution — claim a sponsored game",
  "methods": [
    { "name": "Claim Game",   "description": "Claim your free verified game", "entrypoint": "claim_game" },
    { "name": "Claim Reward", "description": "Claim your reward",             "entrypoint": "claim_reward" }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)