### PR TITLE
Add Karats Dungeon claim_reward to loot-survivor, remove Game Treasury policies

### DIFF
--- a/configs/death-mountain/config.json
+++ b/configs/death-mountain/config.json
@@ -146,22 +146,6 @@
               }
             ]
           },
-          "0x02a71609e235998a5ac140764e768a72a4e40d73e87a0d0858ba561bf875ee87": {
-            "name": "Game Treasury",
-            "description": "Verified-human free game distribution — claim a sponsored game",
-            "methods": [
-              {
-                "name": "Claim Game",
-                "description": "Claim your free verified game",
-                "entrypoint": "claim_game"
-              },
-              {
-                "name": "Claim Reward",
-                "description": "Claim your reward",
-                "entrypoint": "claim_reward"
-              }
-            ]
-          },
           "0x074294d212b0fa295445791b145f2d14e33396a4c2f8415a920f84b2ea3cd5ee": {
             "name": "Onchain Heroes Dungeon",
             "description": "Onchain Heroes Dungeon contract",

--- a/configs/loot-survivor/config.json
+++ b/configs/loot-survivor/config.json
@@ -146,15 +146,10 @@
               }
             ]
           },
-          "0x02a71609e235998a5ac140764e768a72a4e40d73e87a0d0858ba561bf875ee87": {
-            "name": "Game Treasury",
-            "description": "Verified-human free game distribution — claim a sponsored game",
+          "0x0337e25669f6cc7b81a507ebe0d908249cacad9b6e2c0fa43fecb6b6b04b109e": {
+            "name": "Karats Dungeon",
+            "description": "Karats dungeon contract",
             "methods": [
-              {
-                "name": "Claim Game",
-                "description": "Claim your free verified game",
-                "entrypoint": "claim_game"
-              },
               {
                 "name": "Claim Reward",
                 "description": "Claim your reward",


### PR DESCRIPTION
## Summary

- **loot-survivor**: add the Karats dungeon contract `0x0337e25669f6cc7b81a507ebe0d908249cacad9b6e2c0fa43fecb6b6b04b109e` with the `claim_reward` entrypoint, following the same shape as the other dungeon entries.
- **loot-survivor / death-mountain**: remove the Game Treasury policy (`0x02a71609e235998a5ac140764e768a72a4e40d73e87a0d0858ba561bf875ee87`) from both configs — the game treasury is no longer in use.

## Testing

- `pnpm validate:configs` — no issues in the two modified configs (the three reported errors are pre-existing in unrelated configs: dominion, eternum, metal-slug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)