### PR TITLE
Add Budokan tournament policies to loot-survivor

### DIFF
--- a/configs/loot-survivor/config.json
+++ b/configs/loot-survivor/config.json
@@ -234,6 +234,27 @@
                 "entrypoint": "buy_wager_game"
               }
             ]
+          },
+          "0x012eb6054aa269c3e60013693f650650d81952de60072f446406d2a89f0b518e": {
+            "name": "Budokan",
+            "description": "Budokan tournament contract",
+            "methods": [
+              {
+                "name": "Enter Tournament",
+                "description": "Enter a tournament",
+                "entrypoint": "enter_tournament"
+              },
+              {
+                "name": "Submit Score",
+                "description": "Submit your score to a tournament",
+                "entrypoint": "submit_score"
+              },
+              {
+                "name": "Claim Prize",
+                "description": "Claim your tournament prize",
+                "entrypoint": "claim_prize"
+              }
+            ]
           }
         },
         "messages": [


### PR DESCRIPTION
Adds the Budokan tournament contract to the `loot-survivor` preset so players can enter tournaments, submit scores, and claim prizes from lootsurvivor.io without extra session approvals.

Contract `0x012eb6054aa269c3e60013693f650650d81952de60072f446406d2a89f0b518e`:

| Entrypoint | Policy name |
| --- | --- |
| `enter_tournament` | Enter Tournament |
| `submit_score` | Submit Score |
| `claim_prize` | Claim Prize |

Same contract already present in the `budokan` preset; this only exposes the three entrypoints Loot Survivor needs. Change is additive — no existing policies modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)