### PR TITLE
feat(loot-survivor): session policies for the Black Shuck dungeon

### DIFF
--- a/configs/loot-survivor/config.json
+++ b/configs/loot-survivor/config.json
@@ -286,6 +286,22 @@
                 "entrypoint": "claim_prize"
               }
             ]
+          },
+          "0x06bd91881370deb7b7baf55e73bc4c4a37cd29009b491f9fa993dd897c9aba80": {
+            "name": "Black Shuck Dungeon",
+            "description": "Black Shuck Dungeon contract",
+            "methods": [
+              {
+                "name": "Claim Game",
+                "description": "Claim the next free game on your festival code",
+                "entrypoint": "claim"
+              },
+              {
+                "name": "Claim Black Shuck",
+                "description": "Claim the hound for a slain Tier-1 Hunter",
+                "entrypoint": "claim_reward"
+              }
+            ]
           }
         },
         "messages": [


### PR DESCRIPTION
Adds the Black Shuck dungeon to the Loot Survivor preset. The contract is live on mainnet at `0x06bd91881370deb7b7baf55e73bc4c4a37cd29009b491f9fa993dd897c9aba80`.

Two player-facing entrypoints:

| entrypoint | what it does |
|---|---|
| `claim` | claim the next free game on a festival code |
| `claim_reward` | claim the hound for a slain Tier-1 Hunter |

Same shape as the **Gigaverse Dungeon** entry already in this config — a merkle-drop entry claim plus a reward claim.

## Why `claim` needs to be a session policy

Worth calling out, since an entry claim would normally be a one-off approval at signup. A festival code is worth **25 single-game leaves claimed one at a time**, so the player only pays mint gas for games they actually play. That means `claim` is called again from the death screen after every run — not once. Without the policy, each of those 25 claims would interrupt the player with an approval prompt.

## What's deliberately not here

The Black Shuck collectible contract. Players never call it: the dungeon holds the sole minting right (`set_minter_address`) and calls `mint` on their behalf inside `claim_reward`.

## Verification

`pnpm build:configs` regenerates cleanly and the built output carries both entrypoints. The diff is purely additive — no reformatting of existing entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)