### PR TITLE
Add mint_game policy to Karats Dungeon

### DIFF
--- a/configs/loot-survivor/config.json
+++ b/configs/loot-survivor/config.json
@@ -158,6 +158,11 @@
                 "name": "Claim Reward",
                 "description": "Claim your reward",
                 "entrypoint": "claim_reward"
+              },
+              {
+                "name": "Mint Game",
+                "description": "Mint a new game token",
+                "entrypoint": "mint_game"
               }
             ]
           },


### PR DESCRIPTION
Adds the `mint_game` entrypoint to the Karats Dungeon contract (`0x0337e25669f6cc7b81a507ebe0d908249cacad9b6e2c0fa43fecb6b6b04b109e`) in the loot-survivor preset, so sessions can mint game tokens directly from the dungeon without an extra approval prompt.

```json
{
  "name": "Mint Game",
  "description": "Mint a new game token",
  "entrypoint": "mint_game"
}
```

Wording matches the existing Game Token `mint_game` policy in the same preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)