### PR TITLE
Update Budokan contract address in loot-survivor preset

### DIFF
--- a/configs/loot-survivor/config.json
+++ b/configs/loot-survivor/config.json
@@ -266,7 +266,7 @@
               }
             ]
           },
-          "0x012eb6054aa269c3e60013693f650650d81952de60072f446406d2a89f0b518e": {
+          "0x01f2c86ab22ded7f2de9084578ce72a1f7b590d5be6bd5f912ac8053128c20c2": {
             "name": "Budokan",
             "description": "Budokan tournament contract",
             "methods": [


### PR DESCRIPTION
Updates the Budokan tournament contract in the loot-survivor preset from `0x012eb6054aa269c3e60013693f650650d81952de60072f446406d2a89f0b518e` to `0x01f2c86ab22ded7f2de9084578ce72a1f7b590d5be6bd5f912ac8053128c20c2`.

The policy methods (`enter_tournament`, `submit_score`, `claim_prize`) are unchanged; only the contract address moves. Note that the standalone `budokan` preset still points at the old address — happy to update that in a follow-up if it should move too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
