### PR TITLE
Add redeem_with_roll policy to cage-calls

### DIFF
--- a/configs/cage-calls/config.json
+++ b/configs/cage-calls/config.json
@@ -41,6 +41,11 @@
                 "name": "Redeem",
                 "description": "Redeem winnings from a fight",
                 "entrypoint": "redeem"
+              },
+              {
+                "name": "Redeem with Roll",
+                "description": "Redeem fight winnings with a VRF bonus roll",
+                "entrypoint": "redeem_with_roll"
               }
             ]
           },
@@ -101,6 +106,11 @@
                 "name": "Redeem",
                 "description": "Redeem winnings from a fight",
                 "entrypoint": "redeem"
+              },
+              {
+                "name": "Redeem with Roll",
+                "description": "Redeem fight winnings with a VRF bonus roll",
+                "entrypoint": "redeem_with_roll"
               }
             ]
           },


### PR DESCRIPTION
Adds the `redeem_with_roll` entrypoint to the Fight Factory contract in the cage-calls preset, on both SN_MAIN (`0x4beec9af…cbf30`) and SN_SEPOLIA (`0x416b01c9…82d62`), so sessions can redeem fight winnings with the VRF bonus roll without an extra approval prompt.

```json
{
  "name": "Redeem with Roll",
  "description": "Redeem fight winnings with a VRF bonus roll",
  "entrypoint": "redeem_with_roll"
}
```

The entrypoint is live on both chains: the locked-odds FightFactory upgrade (class `0x590a0401…65e1`) was applied and activated on 2026-08-21. It composes with the already-whitelisted `request_random` on the Cartridge VRF Provider (the client multicalls `request_random` → `redeem_with_roll`). The existing `redeem` entry stays — fights created before the locked-odds cutover still redeem through it.

Wording matches the existing Fight Factory policy entries in this preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)